### PR TITLE
Revert "tasks/main.yml: Validate systemd unit files"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,6 @@
     owner: root
     group: root
     mode: 0644
-    validate: systemd-analyze verify %s
   notify: Reload systemd and restart Jenkins slave
 
 - name: Create default file


### PR DESCRIPTION
Reverts stuvusIT/jenkins-slave#3
Validating does not work, because Ansible does not use the correct file suffix in its temp files. That suffix would be needed for systemd to detect the unti type. See https://github.com/ansible/ansible/issues/19232